### PR TITLE
Better handling of repoToken/serviceName/serviceJobId options

### DIFF
--- a/lib/coveralls.js
+++ b/lib/coveralls.js
@@ -27,11 +27,20 @@ function coveralls() {
     convertLcovToCoveralls: function (input, options, callback) {
 
       var postJson = {
-        repo_token: options.repoToken,
-        service_job_id : process.env.TRAVIS_JOB_ID || options.serviceJobId || 'unknown',
-        service_name : options.serviceName,
         source_files : []
       };
+
+      var travisJobId = process.env.TRAVIS_JOB_ID || options.serviceJobId;
+      if (travisJobId && options.serviceName) {
+        postJson.service_job_id = travisJobId;
+        postJson.service_name = options.serviceName;
+      }
+      else if (options.repoToken) {
+        postJson.repo_token = options.repoToken;
+      }
+      else {
+        throw new Error('Can\'t send data to coveralls.io, repo_token (' + options.repoToken + ') or service_job_id (' + travisJobId + ') + service_name (' + options.serviceName + ') should be provided');
+      }
 
       var detailsToCoverage = function (length, details) {
         var coverage = new Array(length);

--- a/test/fixture/fail-gruntfile2.js
+++ b/test/fixture/fail-gruntfile2.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    mochacov: {
+      overage: {
+        options: {
+          coveralls: {
+            repo_token: 'xyz123',
+            serviceJobId: 12345678,
+            serviceName: 'travis-ci',
+            files: [__dirname + '/pass.js']
+          }
+        }
+      }
+    }
+  });
+
+  grunt.loadTasks(__dirname + '/../../tasks');
+
+  grunt.registerTask('default', 'mochacov');
+};

--- a/test/mochacov.js
+++ b/test/mochacov.js
@@ -27,6 +27,18 @@ exports['grunt fail'] = function (test) {
   });
 };
 
+exports['grunt fail missing repo_token or service_job_id + service_name'] = function (test) {
+  test.expect(1);
+
+  grunt.util.spawn({
+    cmd: 'grunt',
+    args: ['--gruntfile', __dirname + '/fixture/fail-gruntfile2.js']
+  }, function (error, output, code) {
+    test.notStrictEqual(code, 0, 'grunt should fail');
+    test.done();
+  });
+};
+
 exports['grunt glob'] = function (test) {
   test.expect(2);
 


### PR DESCRIPTION
Set service_job_id+service_name and repo_token mutally exclusively, throw if neither available, give service_job_id+service_name precidence over repo_token, don't set service_job_id to 'unknown'. Fixes #2
