### PR TITLE
Allow to pass CLI options to mocha

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,19 +1,215 @@
 {
   "name": "grunt-mocha-cov",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {
+    "blanket": {
+      "version": "1.1.6",
+      "from": "blanket@1.1.6",
+      "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
+        "falafel": {
+          "version": "0.1.6",
+          "from": "falafel@0.1.6",
+          "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "from": "xtend@2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "dependencies": {
+            "object-keys": {
+              "version": "0.4.0",
+              "from": "object-keys@0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "coveralls": {
+      "version": "2.6.1",
+      "from": "coveralls@2.6.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.6.1.tgz",
+      "dependencies": {
+        "yaml": {
+          "version": "0.2.3",
+          "from": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz"
+        },
+        "request": {
+          "version": "2.16.2",
+          "from": "https://registry.npmjs.org/request/-/request-2.16.2.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.16.2.tgz",
+          "dependencies": {
+            "form-data": {
+              "version": "0.0.10",
+              "from": "form-data@0.0.10",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.4",
+                  "from": "combined-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.2.9",
+                  "from": "async@0.2.9"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "hawk": {
+              "version": "0.10.2",
+              "from": "hawk@0.10.2",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.7.6",
+                  "from": "hoek@0.7.6",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
+                },
+                "boom": {
+                  "version": "0.3.8",
+                  "from": "boom@0.3.8",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.1.3",
+                  "from": "cryptiles@0.1.3",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
+                },
+                "sntp": {
+                  "version": "0.1.4",
+                  "from": "sntp@0.1.4",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.1",
+              "from": "node-uuid@1.4.1",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+            },
+            "cookie-jar": {
+              "version": "0.2.0",
+              "from": "cookie-jar@0.2.0",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
+            },
+            "aws-sign": {
+              "version": "0.2.0",
+              "from": "aws-sign@0.2.0",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.2.0",
+              "from": "oauth-sign@0.2.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.2.0",
+              "from": "forever-agent@0.2.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.2.0",
+              "from": "tunnel-agent@0.2.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "3.0.0",
+              "from": "json-stringify-safe@3.0.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
+            },
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@0.5.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            }
+          }
+        },
+        "lcov-parse": {
+          "version": "0.0.4",
+          "from": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.4.tgz"
+        },
+        "log-driver": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.1.tgz"
+        }
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.6",
+      "from": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
+    },
+    "lodash.defaults": {
+      "version": "2.4.1",
+      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "dependencies": {
+            "lodash._isnative": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+            },
+            "lodash.isobject": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
+            },
+            "lodash._shimkeys": {
+              "version": "2.4.1",
+              "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+            }
+          }
+        },
+        "lodash._objecttypes": {
+          "version": "2.4.1",
+          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "from": "mkdirp@0.3.5"
+    },
     "mocha": {
-      "version": "1.17.1",
-      "from": "mocha@*",
+      "version": "1.17.0",
+      "from": "mocha@1.17.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.17.0.tgz",
       "dependencies": {
         "commander": {
           "version": "2.0.0",
-          "from": "commander@2.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+          "from": "commander@2.0.0"
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@1.7.x"
+          "from": "growl@1.7.0",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "jade": {
           "version": "0.26.3",
@@ -35,7 +231,8 @@
         },
         "debug": {
           "version": "0.7.4",
-          "from": "debug@*"
+          "from": "debug@0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
         },
         "glob": {
           "version": "3.2.3",
@@ -44,99 +241,102 @@
             "minimatch": {
               "version": "0.2.14",
               "from": "minimatch@~0.2.11",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.1",
-              "from": "graceful-fs@~2.0.0"
+              "from": "graceful-fs@2.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
       }
     },
-    "blanket": {
-      "version": "1.1.6",
-      "from": "blanket@*",
+    "mocha-lcov-reporter": {
+      "version": "0.0.1",
+      "from": "mocha-lcov-reporter@0.0.1"
+    },
+    "optimist": {
+      "version": "0.6.0",
+      "from": "optimist@",
       "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "from": "esprima@~ 1.0.2"
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@~0.0.2"
         },
-        "falafel": {
-          "version": "0.1.6",
-          "from": "falafel@~0.1.6"
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "from": "xtend@~2.1.1",
-          "dependencies": {
-            "object-keys": {
-              "version": "0.4.0",
-              "from": "object-keys@~0.4.0"
-            }
-          }
+        "minimist": {
+          "version": "0.0.5",
+          "from": "minimist@~0.0.1"
         }
       }
-    },
-    "lcov-parse": {
-      "version": "0.0.6",
-      "from": "lcov-parse@*"
     },
     "request": {
       "version": "2.33.0",
-      "from": "request@*",
+      "from": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "qs@~0.6.0"
+          "from": "qs@0.6.6"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0"
+          "from": "json-stringify-safe@5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "forever-agent": {
-          "version": "0.5.2",
-          "from": "forever-agent@~0.5.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+          "version": "0.5.0",
+          "from": "forever-agent@0.5.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.0.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0"
+          "from": "node-uuid@1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.9"
+          "from": "mime@1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.2.3",
-              "from": "punycode@>=0.2.0"
+              "from": "punycode@1.2.3",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.3.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.2",
-          "from": "form-data@~0.1.0",
+          "from": "form-data@0.1.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
-              "from": "combined-stream@~0.0.4",
+              "from": "combined-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
@@ -145,18 +345,20 @@
               }
             },
             "async": {
-              "version": "0.2.10",
-              "from": "async@~0.2.9"
+              "version": "0.2.9",
+              "from": "async@0.2.9"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@~0.3.0"
+          "from": "tunnel-agent@0.3.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@~0.10.0",
+          "from": "http-signature@0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
@@ -174,176 +376,40 @@
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0"
+          "from": "oauth-sign@0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.0.0",
-          "from": "hawk@~1.0.0",
+          "from": "hawk@1.0.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.2",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.2",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.4",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0"
-        }
-      }
-    },
-    "mocha-lcov-reporter": {
-      "version": "0.0.1",
-      "from": "mocha-lcov-reporter@*"
-    },
-    "mkdirp": {
-      "version": "0.3.5",
-      "from": "mkdirp@*"
-    },
-    "coveralls": {
-      "version": "2.7.1",
-      "from": "coveralls@*",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.7.1.tgz",
-      "dependencies": {
-        "yaml": {
-          "version": "0.2.3",
-          "from": "yaml@0.2.3",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz"
-        },
-        "request": {
-          "version": "2.16.2",
-          "from": "request@2.16.2",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.16.2.tgz",
-          "dependencies": {
-            "form-data": {
-              "version": "0.0.10",
-              "from": "form-data@~0.0.3",
-              "dependencies": {
-                "combined-stream": {
-                  "version": "0.0.4",
-                  "from": "combined-stream@~0.0.4",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5"
-                    }
-                  }
-                },
-                "async": {
-                  "version": "0.2.10",
-                  "from": "async@~0.2.7"
-                }
-              }
-            },
-            "mime": {
-              "version": "1.2.11",
-              "from": "mime@~1.2.7"
-            },
-            "hawk": {
-              "version": "0.10.2",
-              "from": "hawk@~0.10.0",
-              "dependencies": {
-                "hoek": {
-                  "version": "0.7.6",
-                  "from": "hoek@0.7.x"
-                },
-                "boom": {
-                  "version": "0.3.8",
-                  "from": "boom@0.3.x"
-                },
-                "cryptiles": {
-                  "version": "0.1.3",
-                  "from": "cryptiles@0.1.x"
-                },
-                "sntp": {
-                  "version": "0.1.4",
-                  "from": "sntp@0.1.x"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.1",
-              "from": "node-uuid@~1.4.0"
-            },
-            "cookie-jar": {
-              "version": "0.2.0",
-              "from": "cookie-jar@~0.2.0"
-            },
-            "aws-sign": {
-              "version": "0.2.0",
-              "from": "aws-sign@~0.2.0"
-            },
-            "oauth-sign": {
-              "version": "0.2.0",
-              "from": "oauth-sign@~0.2.0"
-            },
-            "forever-agent": {
-              "version": "0.2.0",
-              "from": "forever-agent@~0.2.0"
-            },
-            "tunnel-agent": {
-              "version": "0.2.0",
-              "from": "tunnel-agent@~0.2.0"
-            },
-            "json-stringify-safe": {
-              "version": "3.0.0",
-              "from": "json-stringify-safe@~3.0.0"
-            },
-            "qs": {
-              "version": "0.5.6",
-              "from": "qs@~0.5.0"
-            }
-          }
-        },
-        "lcov-parse": {
-          "version": "0.0.4",
-          "from": "lcov-parse@0.0.4",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.4.tgz"
-        },
-        "log-driver": {
-          "version": "1.2.1",
-          "from": "log-driver@1.2.1",
-          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.1.tgz"
-        }
-      }
-    },
-    "lodash.defaults": {
-      "version": "2.4.1",
-      "from": "lodash.defaults@*",
-      "dependencies": {
-        "lodash.keys": {
-          "version": "2.4.1",
-          "from": "lodash.keys@~2.4.1",
-          "dependencies": {
-            "lodash._isnative": {
-              "version": "2.4.1",
-              "from": "lodash._isnative@~2.4.1"
-            },
-            "lodash.isobject": {
-              "version": "2.4.1",
-              "from": "lodash.isobject@~2.4.1"
-            },
-            "lodash._shimkeys": {
-              "version": "2.4.1",
-              "from": "lodash._shimkeys@~2.4.1"
-            }
-          }
-        },
-        "lodash._objecttypes": {
-          "version": "2.4.1",
-          "from": "lodash._objecttypes@~2.4.1"
+          "from": "aws-sign2@0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,26 +32,27 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "mocha": "*",
     "blanket": "*",
-    "lcov-parse": "*",
-    "request": "*",
-    "mocha-lcov-reporter": "*",
-    "mkdirp": "*",
     "coveralls": "*",
-    "lodash.defaults": "*"
+    "lcov-parse": "*",
+    "lodash.defaults": "*",
+    "mkdirp": "*",
+    "mocha": "*",
+    "mocha-lcov-reporter": "*",
+    "optimist": "*",
+    "request": "*"
   },
   "peerDependencies": {
     "grunt": "*"
   },
   "devDependencies": {
+    "chai": "*",
+    "coffee-script": "*",
     "grunt": "*",
     "grunt-cli": "*",
     "grunt-contrib-jshint": "*",
-    "coffee-script": "*",
-    "chai": "*",
-    "should": "*",
-    "mocha-term-cov-reporter": "*"
+    "mocha-term-cov-reporter": "*",
+    "should": "*"
   },
   "scripts": {
     "test": "./node_modules/.bin/grunt test"

--- a/tasks/mochacov.js
+++ b/tasks/mochacov.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+var optimist = require('optimist');
+var defaults = require('lodash.defaults');
 var mocha = require('../lib/mocha');
 
 
@@ -27,7 +29,8 @@ function MochaCov(grunt) {
     'mochacov',
     'Run Mocha server-side tests in Grunt with code coverage support and optional integration to coveralls.io.',
     function () {
-      var options = this.options();
+      var argv = optimist.parse(grunt.option.flags());
+      var options = defaults(argv, this.options());
       var globs = [];
 
       // Use the Grunt files format if the `files` option isn't set

--- a/test/fixture/cli-options-gruntfile.js
+++ b/test/fixture/cli-options-gruntfile.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function (grunt) {
+  grunt.initConfig({
+    mochacov: {
+      options: {
+        require: ['should']
+      },
+      all: [__dirname + '/require.js']
+    }
+  });
+
+  grunt.loadTasks(__dirname + '/../../tasks');
+
+  grunt.registerTask('default', 'mochacov');
+};

--- a/test/fixture/require.js
+++ b/test/fixture/require.js
@@ -4,4 +4,8 @@ describe('fixture', function () {
   it('require', function () {
     true.should.equal(true);
   });
+
+  it('cli-options-gruntfile', function () {
+    true.should.equal(true);
+  });
 });

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -93,7 +93,7 @@ describe('Unit Tests', function () {
     }, function (error, output) {
       should.not.exist(error);
       output = JSON.parse(output);
-      output.stats.passes.should.equal(1);
+      output.stats.passes.should.equal(2);
       done();
     });
   });

--- a/test/mochacov.js
+++ b/test/mochacov.js
@@ -110,4 +110,17 @@ describe('Integration Tests', function () {
     });
   });
 
+  it('should test passing grunt CLI options to mocha', function (done) {
+
+    grunt.util.spawn({
+      cmd: 'grunt',
+      args: ['--gruntfile', __dirname + '/fixture/cli-options-gruntfile.js', '--grep=cli-options-gruntfile']
+    }, function (error, output, code) {
+      should.not.exist(error);
+      code.should.equals(0);
+      output.toString().should.contain('1 passing');
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
The idea behing this changeset is pretty simple. I'm too lazy to modify
my Gruntfile everytime i want to pass any option to mocha just for
single run. For instance if you have 1 failing test, you don't want to
run other ones and waste your time, you want to grep this particular one
that is failing and keep working on it until it's fixed so i'd prefer to
pass --grep from CLI rather than modify Gruntfile that would appear in
git status and rollback it later when i'm done.

Options passed via CLI have higher precedence than options passed via
Gruntfile so you can easly override them whenever you want to.

I'm using optimist to parse CLI options and i'm using grunt.option.flags() to get those instead of process.argv

P.S. I've sorted npm dependencies and devDependencies as i didn't know where to put optimist :) I hope it doesn't hurt anyone's feelings.
