### PR TITLE
Windows compat fixes

### DIFF
--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -9,7 +9,11 @@ var grunt = require('grunt'),
     path = require('path'),
     fs = require('fs'),
     mkdirp = require('mkdirp'),
-    coveralls = require('coveralls');
+    coveralls = require('coveralls'),
+    temp = require('temp');
+
+// delete temp files, please!
+temp.track();
 
 // expose mocha
 exports = module.exports = mocha;
@@ -105,18 +109,14 @@ function mocha(options, callback) {
 
   var args = [],
       mochaBasePath = path.dirname(require.resolve('mocha')),
-      spawnOptions = { cmd: path.normalize(mochaBasePath + '/../.bin/mocha') };
+      spawnOptions = { cmd: path.normalize(mochaBasePath + '/../.bin/mocha') },
+      fd_out, fd_err;
 
   if (process.platform === 'win32') {
     spawnOptions.cmd += '.cmd';
   }
 
   options = getBaseOptions(options);
-
-  if (!options.quiet && !options.output) {
-    // Redirect the Mocha output directly to the terminal to maintain colors
-    spawnOptions.opts = { stdio: 'inherit' };
-  }
 
   BOOL_OPTIONS.forEach(function (option) {
     if (options[option]) {
@@ -149,12 +149,49 @@ function mocha(options, callback) {
 
   spawnOptions.args = args;
 
+  if (!options.coveralls && options.output) {
+    var filename = path.resolve(options.output),
+        dir = path.dirname(filename);
+
+    if (!fs.existsSync(dir)) {
+      mkdirp.sync(dir);
+    }
+    fd_out = {
+      fd: fs.openSync(filename, 'w'),
+      path: filename
+    };
+
+    spawnOptions.opts = { stdio: ['ignore', fd_out.fd, fd_out.fd] };
+  } else if (!options.quiet && !options.output) {
+    // Redirect the Mocha output directly to the terminal to maintain colors
+    spawnOptions.opts = { stdio: 'inherit' };
+  } else if (process.platform === 'win32') {
+    // We need to redirect to a temp file in order for everyone to be happy on Windows.
+
+    fd_out = temp.openSync('grunt-mocha-cov');
+    fd_err = temp.openSync('grunt-mocha-cov');
+
+    spawnOptions.opts = { stdio: ['ignore', fd_out.fd, fd_err.fd] };
+
+  }
+
   // Run mocha test in new process with coverage support
   grunt.util.spawn(spawnOptions, function (error, result) {
+    if (fd_out) {
+      fs.closeSync(fd_out.fd);
+      result = {
+        stdout: fs.readFileSync(fd_out.path, 'utf8')
+      };
+
+      if (fd_err) {
+        fs.closeSync(fd_err.fd);
+        result.stderr = fs.readFileSync(fd_err.path, 'utf8');
+      }
+    }
+
     if (error) {
       return callback(error, result.stdout + result.stderr);
     }
-
     // Send output to coveralls
     // Format should be LCov
     if (options.coveralls) {
@@ -199,21 +236,8 @@ function mocha(options, callback) {
 
     // Save report to disk
     } else if (options.output) {
-
-      var filename = path.resolve(options.output),
-          dir = path.dirname(filename);
-
-      fs.stat(dir, function (err) {
-
-        if (err) {
-          mkdirp.sync(dir);
-        }
-
-        fs.writeFile(filename, String(result), 'utf8', function (err) {
-          callback(err);
-        });
-
-      });
+      //We've already saved output by redirecting spawn() to an fd
+      callback();
 
     // Send report to stdout
     } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,10 +1,11 @@
 {
   "name": "grunt-mocha-cov",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {
     "mocha": {
       "version": "1.17.1",
-      "from": "mocha@*",
+      "from": "mocha@1.17.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.17.1.tgz",
       "dependencies": {
         "commander": {
           "version": "2.0.0",
@@ -13,55 +14,67 @@
         },
         "growl": {
           "version": "1.7.0",
-          "from": "growl@1.7.x"
+          "from": "growl@1.7.0",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
         },
         "jade": {
           "version": "0.26.3",
           "from": "jade@0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
           "dependencies": {
             "commander": {
               "version": "0.6.1",
-              "from": "commander@0.6.1"
+              "from": "commander@0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
             },
             "mkdirp": {
               "version": "0.3.0",
-              "from": "mkdirp@0.3.0"
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
             }
           }
         },
         "diff": {
           "version": "1.0.7",
-          "from": "diff@1.0.7"
+          "from": "diff@1.0.7",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
         },
         "debug": {
           "version": "0.7.4",
-          "from": "debug@*"
+          "from": "debug@0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
         },
         "glob": {
           "version": "3.2.3",
           "from": "glob@3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.2.14",
               "from": "minimatch@~0.2.11",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2"
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0"
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "2.0.1",
-              "from": "graceful-fs@~2.0.0"
+              "from": "graceful-fs@2.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2"
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -69,23 +82,28 @@
     },
     "blanket": {
       "version": "1.1.6",
-      "from": "blanket@*",
+      "from": "blanket@1.1.6",
+      "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "from": "esprima@~ 1.0.2"
+          "from": "esprima@1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
         },
         "falafel": {
           "version": "0.1.6",
-          "from": "falafel@~0.1.6"
+          "from": "falafel@0.1.6",
+          "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
         },
         "xtend": {
           "version": "2.1.2",
-          "from": "xtend@~2.1.1",
+          "from": "xtend@2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "dependencies": {
             "object-keys": {
               "version": "0.4.0",
-              "from": "object-keys@~0.4.0"
+              "from": "object-keys@0.4.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
             }
           }
         }
@@ -93,134 +111,184 @@
     },
     "lcov-parse": {
       "version": "0.0.6",
-      "from": "lcov-parse@*"
+      "from": "lcov-parse@0.0.6",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
     },
     "request": {
       "version": "2.33.0",
-      "from": "request@*",
+      "from": "request@2.33.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.33.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "qs@~0.6.0"
+          "from": "qs@0.6.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0"
+          "from": "json-stringify-safe@5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0",
+          "from": "forever-agent@0.5.2",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0"
+          "from": "node-uuid@1.4.1",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.9"
+          "from": "mime@1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "tough-cookie": {
           "version": "0.12.1",
-          "from": "tough-cookie@>=0.12.0",
+          "from": "tough-cookie@0.12.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.2.3",
-              "from": "punycode@>=0.2.0"
+              "from": "punycode@1.2.3",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.3.tgz"
             }
           }
         },
         "form-data": {
           "version": "0.1.2",
-          "from": "form-data@~0.1.0",
+          "from": "form-data@0.1.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.2.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.4",
-              "from": "combined-stream@~0.0.4",
+              "from": "combined-stream@0.0.4",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5"
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                 }
               }
             },
             "async": {
               "version": "0.2.10",
-              "from": "async@~0.2.9"
+              "from": "async@0.2.10",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.3.0",
-          "from": "tunnel-agent@~0.3.0"
+          "from": "tunnel-agent@0.3.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
         },
         "http-signature": {
           "version": "0.10.0",
-          "from": "http-signature@~0.10.0",
+          "from": "http-signature@0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2"
+              "from": "assert-plus@0.1.2",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11"
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2"
+              "from": "ctype@0.5.2",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0"
+          "from": "oauth-sign@0.3.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
         },
         "hawk": {
           "version": "1.0.0",
-          "from": "hawk@~1.0.0",
+          "from": "hawk@1.0.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x"
+              "from": "hoek@0.9.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x"
+              "from": "boom@0.4.2",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x"
+              "from": "cryptiles@0.2.2",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x"
+              "from": "sntp@0.2.4",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0"
+          "from": "aws-sign2@0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
         }
       }
     },
     "mocha-lcov-reporter": {
       "version": "0.0.1",
-      "from": "mocha-lcov-reporter@*"
+      "from": "mocha-lcov-reporter@0.0.1",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.1.tgz"
     },
     "mkdirp": {
       "version": "0.3.5",
-      "from": "mkdirp@*"
+      "from": "mkdirp@0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
     },
     "coveralls": {
-      "version": "2.7.1",
-      "from": "coveralls@*",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.7.1.tgz",
+      "version": "2.8.0",
+      "from": "coveralls@2.8.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.8.0.tgz",
       "dependencies": {
-        "yaml": {
-          "version": "0.2.3",
-          "from": "yaml@0.2.3",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz"
+        "js-yaml": {
+          "version": "3.0.1",
+          "from": "js-yaml@3.0.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@~1.4.3",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.1",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
         },
         "request": {
           "version": "2.16.2",
@@ -229,88 +297,101 @@
           "dependencies": {
             "form-data": {
               "version": "0.0.10",
-              "from": "form-data@~0.0.3",
+              "from": "form-data@0.0.10",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
               "dependencies": {
                 "combined-stream": {
                   "version": "0.0.4",
-                  "from": "combined-stream@~0.0.4",
+                  "from": "combined-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5"
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@~0.2.7"
+                  "from": "async@0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.2.11",
-              "from": "mime@~1.2.7"
+              "from": "mime@1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             },
             "hawk": {
               "version": "0.10.2",
-              "from": "hawk@~0.10.0",
+              "from": "hawk@0.10.2",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.7.6",
-                  "from": "hoek@0.7.x"
+                  "from": "hoek@0.7.6",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
                 },
                 "boom": {
                   "version": "0.3.8",
-                  "from": "boom@0.3.x"
+                  "from": "boom@0.3.8",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
                 },
                 "cryptiles": {
                   "version": "0.1.3",
-                  "from": "cryptiles@0.1.x"
+                  "from": "cryptiles@0.1.3",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
                 },
                 "sntp": {
                   "version": "0.1.4",
-                  "from": "sntp@0.1.x"
+                  "from": "sntp@0.1.4",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.1",
-              "from": "node-uuid@~1.4.0"
+              "from": "node-uuid@1.4.1",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
             },
             "cookie-jar": {
               "version": "0.2.0",
-              "from": "cookie-jar@~0.2.0"
+              "from": "cookie-jar@0.2.0",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
             },
             "aws-sign": {
               "version": "0.2.0",
-              "from": "aws-sign@~0.2.0"
+              "from": "aws-sign@0.2.0",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
             },
             "oauth-sign": {
               "version": "0.2.0",
-              "from": "oauth-sign@~0.2.0"
+              "from": "oauth-sign@0.2.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
             },
             "forever-agent": {
               "version": "0.2.0",
-              "from": "forever-agent@~0.2.0"
+              "from": "forever-agent@0.2.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.2.0",
-              "from": "tunnel-agent@~0.2.0"
+              "from": "tunnel-agent@0.2.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
             },
             "json-stringify-safe": {
               "version": "3.0.0",
-              "from": "json-stringify-safe@~3.0.0"
+              "from": "json-stringify-safe@3.0.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
             },
             "qs": {
               "version": "0.5.6",
-              "from": "qs@~0.5.0"
+              "from": "qs@0.5.6",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
             }
           }
-        },
-        "lcov-parse": {
-          "version": "0.0.4",
-          "from": "lcov-parse@0.0.4",
-          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.4.tgz"
         },
         "log-driver": {
           "version": "1.2.1",
@@ -321,29 +402,59 @@
     },
     "lodash.defaults": {
       "version": "2.4.1",
-      "from": "lodash.defaults@*",
+      "from": "lodash.defaults@2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@~2.4.1",
+          "from": "lodash.keys@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "dependencies": {
             "lodash._isnative": {
               "version": "2.4.1",
-              "from": "lodash._isnative@~2.4.1"
+              "from": "lodash._isnative@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
             },
             "lodash.isobject": {
               "version": "2.4.1",
-              "from": "lodash.isobject@~2.4.1"
+              "from": "lodash.isobject@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
             },
             "lodash._shimkeys": {
               "version": "2.4.1",
-              "from": "lodash._shimkeys@~2.4.1"
+              "from": "lodash._shimkeys@2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
             }
           }
         },
         "lodash._objecttypes": {
           "version": "2.4.1",
-          "from": "lodash._objecttypes@~2.4.1"
+          "from": "lodash._objecttypes@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+        }
+      }
+    },
+    "temp": {
+      "version": "0.6.0",
+      "from": "temp@0.6.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@2.1.4",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            }
+          }
+        },
+        "osenv": {
+          "version": "0.0.3",
+          "from": "osenv@0.0.3",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "mocha-lcov-reporter": "*",
     "mkdirp": "*",
     "coveralls": "*",
-    "lodash.defaults": "*"
+    "lodash.defaults": "*",
+    "temp": "*"
   },
   "peerDependencies": {
     "grunt": "*"

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -1,5 +1,5 @@
 {
-  "scripts": {
+  "config": {
     "blanket": {
       "pattern": [
         "test/fixture/pass"

--- a/test/mochacov.js
+++ b/test/mochacov.js
@@ -4,7 +4,10 @@ var grunt = require('grunt'),
     path = require('path'),
     fs = require('fs'),
     chai = require('chai'),
-    should = chai.should();
+    should = chai.should(),
+    temp = require('temp');
+
+temp.track();
 
 describe('Integration Tests', function () {
 
@@ -43,14 +46,18 @@ describe('Integration Tests', function () {
   });
 
   it('should test grunt file glob', function (done) {
-
+    var fd_out = temp.openSync('grunt-mocha-cov-test');
     grunt.util.spawn({
       cmd: 'grunt',
-      args: ['--gruntfile', __dirname + '/fixture/glob-gruntfile.js']
+      args: ['--gruntfile', __dirname + '/fixture/glob-gruntfile.js'],
+      opts: {
+        stdio: ['ignore', fd_out.fd, 'ignore'],
+      },
     }, function (error, output, code) {
       should.not.exist(error);
       code.should.equals(0);
-      output.stdout.should.include('2 passing');
+      fs.closeSync(fd_out.fd);
+      fs.readFileSync(fd_out.path, 'utf8').should.include('2 passing');
       done();
     });
   });
@@ -68,14 +75,19 @@ describe('Integration Tests', function () {
   });
 
   it('should test grunt coverage', function (done) {
+    var fd_out = temp.openSync('grunt-mocha-cov-test');
 
     grunt.util.spawn({
       cmd: 'grunt',
-      args: ['--gruntfile', __dirname + '/fixture/coverage-gruntfile.js']
+      args: ['--gruntfile', __dirname + '/fixture/coverage-gruntfile.js'],
+      opts: {
+        stdio: ['ignore', fd_out.fd, 'ignore'],
+      },
     }, function (error, output, code) {
       should.not.exist(error);
       code.should.equals(0);
-      output.stdout.should.include('"coverage": 100');
+      fs.closeSync(fd_out.fd);
+      fs.readFileSync(fd_out.path, 'utf8').toString().should.include('"coverage": 100');
       done();
     });
   });


### PR DESCRIPTION
Fix windows compat by redirecting stdout/stderr to FDs rather than
depending on it being piped back via spawn().

Works around issue: https://github.com/visionmedia/mocha/issues/333
