### PR TITLE
Bail only if option is set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 /npm-debug.log
+.idea/

--- a/lib/mocha.js
+++ b/lib/mocha.js
@@ -162,7 +162,7 @@ function mocha(options, callback) {
 
   // Run mocha test in new process with coverage support
   grunt.util.spawn(spawnOptions, function (error, result) {
-    if (error) {
+    if (error && options.bail) {
       return callback(error, result.stdout + result.stderr);
     }
 


### PR DESCRIPTION
Mocha provides the --bail option, and grunt-mocha-cov should also.
Fixed #37
