### PR TITLE
Updated some dependencies to allow newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
     "lcov-parse": "0.0.9",
     "lodash.defaults": "3.0.0",
     "mkdirp": "0.5.0",
-    "mocha": "2.2.1",
+    "mocha": ">=2.2.1",
     "mocha-lcov-reporter": "0.0.2",
     "request": "2.53.0"
   },
   "devDependencies": {
     "chai": "2.1.2",
     "coffee-script": "1.9.1",
-    "grunt": "0.4.5",
-    "grunt-cli": "0.1.13",
-    "grunt-contrib-jshint": "0.11.1",
-    "mocha-term-cov-reporter": "0.2.0",
+    "grunt": ">=0.4.5",
+    "grunt-cli": ">=0.1.13",
+    "grunt-contrib-jshint": ">=0.11.1",
+    "mocha-term-cov-reporter": ">=0.2.0",
     "should": "5.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
These particular dependencies are receiving deprecated warnings. I just updated to allow newer versions of the dependencies. All tests still pass.
